### PR TITLE
Fix typo in datetime format for nifi homework

### DIFF
--- a/labs/nifi/homework/README.md
+++ b/labs/nifi/homework/README.md
@@ -2,6 +2,6 @@
 
 Save bitstamp messages to the local file system on a master node every minute
 
-Folder structure on local file system: /home/nifi/yyyy-mm-dd-hh-MM
+Folder structure on local file system: /home/nifi/yyyy-MM-dd-HH-mm
 
 !DON'T FORGET TO STOP YOUR PROCESSORS AFTER TESTING


### PR DESCRIPTION
The result of the format `yyyy-mm-dd-hh-MM` will be something like `2020-34-17-11-11`, here `mm` - is minutes

[Source:](https://www.w3.org/TR/NOTE-datetime)
```
     YYYY = four-digit year
     MM   = two-digit month (01=January, etc.)
     DD   = two-digit day of month (01 through 31)
     hh   = two digits of hour (00 through 12) (am/pm NOT allowed)
     mm   = two digits of minute (00 through 59)
     ss   = two digits of second (00 through 59)
     s    = one or more digits representing a decimal fraction of a second
     TZD  = time zone designator (Z or +hh:mm or -hh:mm)
```

It should be replaced by `MM`. Also, it would be better to use a 24-hour clock:

`yyyy-MM-dd-HH-mm` = `2020-11-17-12-34`

Please review,
Thank you in advance